### PR TITLE
Fix annotation error message box

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -110,8 +110,7 @@ class VSAnnotationProvider {
             return this.rawProvider.annotate(sourcePath);
         } catch (e) {
             vscode.window.showErrorMessage(
-                `Got an error while annotating file "${sourcePath}"`,
-                e.stderr.toString());
+                `Got an error while annotating file "${sourcePath}": ${e.stderr.toString()}`);
             return null;
         }
     }


### PR DESCRIPTION
This PR fixes the issue that the details of annotation errors are displayed as an action item button thus cannot be read.