### PR TITLE
All cython arguments are provided by args

### DIFF
--- a/src/annotator.ts
+++ b/src/annotator.ts
@@ -52,9 +52,9 @@ class CythonExecutor {
                 default:
                     throw Error(`Unsupported operating system: ${os.platform()}`);
             }
-            cythonCmd = `${condaCmd} && cython -a ${args.join(' ')}`;
+            cythonCmd = `${condaCmd} && cython ${args.join(' ')}`;
         } else {
-            cythonCmd = `cython -a ${args.join(' ')}`;
+            cythonCmd = `cython ${args.join(' ')}`;
         }
 
         ChildProcess.execFileSync(


### PR DESCRIPTION
This avoids specifying `-a` twice.